### PR TITLE
Add webpage download helper

### DIFF
--- a/download_page_resources.py
+++ b/download_page_resources.py
@@ -1,0 +1,72 @@
+import os
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse
+
+
+def download_file(url, folder):
+    filename = os.path.basename(urlparse(url).path)
+    if not filename:
+        filename = 'index'
+    local_path = os.path.join(folder, filename)
+    r = requests.get(url, stream=True)
+    r.raise_for_status()
+    with open(local_path, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=8192):
+            f.write(chunk)
+    return local_path
+
+
+def main():
+    url = input("Enter URL: ").strip()
+    if not url:
+        print("No URL provided")
+        return
+    if not urlparse(url).scheme:
+        url = 'http://' + url
+
+    response = requests.get(url)
+    response.raise_for_status()
+    html = response.text
+
+    save_dir = 'downloaded_files'
+    os.makedirs(save_dir, exist_ok=True)
+
+    html_file = os.path.join(save_dir, 'page.html')
+    with open(html_file, 'w', encoding=response.encoding or 'utf-8') as f:
+        f.write(html)
+    print(f"Saved main page to {html_file}")
+
+    choice = input("Download linked resources? (y/n): ").strip().lower()
+    if choice != 'y':
+        return
+
+    soup = BeautifulSoup(html, 'html.parser')
+    resource_urls = []
+    for tag in soup.find_all(['img', 'script', 'link', 'a']):
+        if tag.name == 'img' and tag.get('src'):
+            resource_urls.append(urljoin(url, tag['src']))
+        elif tag.name == 'script' and tag.get('src'):
+            resource_urls.append(urljoin(url, tag['src']))
+        elif tag.name == 'link' and tag.get('href'):
+            if tag.get('rel') and 'stylesheet' in tag.get('rel'):
+                resource_urls.append(urljoin(url, tag['href']))
+        elif tag.name == 'a' and tag.get('href'):
+            href = tag['href']
+            if not href.startswith('#'):
+                resource_urls.append(urljoin(url, href))
+
+    seen = set()
+    for res_url in resource_urls:
+        if res_url in seen:
+            continue
+        seen.add(res_url)
+        try:
+            print(f"Downloading {res_url}...")
+            download_file(res_url, save_dir)
+        except Exception as e:
+            print(f"Failed to download {res_url}: {e}")
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/download.html
+++ b/templates/download.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Web Page Downloader</title>
+</head>
+<body>
+    <h1>Web Page Downloader</h1>
+    <form method="post">
+        <label for="url">URL:</label>
+        <input type="text" id="url" name="url" required>
+        <br>
+        <label>
+            <input type="checkbox" name="resources"> Download linked resources
+        </label>
+        <br>
+        <button type="submit">Download</button>
+    </form>
+    {% if error %}
+    <p style="color:red">{{ error }}</p>
+    {% endif %}
+</body>
+</html>

--- a/web_downloader.py
+++ b/web_downloader.py
@@ -1,0 +1,80 @@
+from flask import Flask, render_template, request, send_file
+import os
+import shutil
+import tempfile
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse
+
+app = Flask(__name__)
+
+
+def download_file(url: str, folder: str) -> str:
+    """Download a single file to the given folder and return the local path."""
+    filename = os.path.basename(urlparse(url).path)
+    if not filename:
+        filename = 'index'
+    local_path = os.path.join(folder, filename)
+    r = requests.get(url, stream=True)
+    r.raise_for_status()
+    with open(local_path, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=8192):
+            f.write(chunk)
+    return local_path
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        url = request.form.get('url', '').strip()
+        download_resources = request.form.get('resources') == 'on'
+        if not url:
+            return render_template('download.html', error='No URL provided')
+        if not urlparse(url).scheme:
+            url = 'http://' + url
+
+        temp_dir = tempfile.mkdtemp()
+        try:
+            resp = requests.get(url)
+            resp.raise_for_status()
+
+            html_path = os.path.join(temp_dir, 'page.html')
+            with open(html_path, 'w', encoding=resp.encoding or 'utf-8') as f:
+                f.write(resp.text)
+
+            if download_resources:
+                soup = BeautifulSoup(resp.text, 'html.parser')
+                resource_urls = []
+                for tag in soup.find_all(['img', 'script', 'link', 'a']):
+                    if tag.name == 'img' and tag.get('src'):
+                        resource_urls.append(urljoin(url, tag['src']))
+                    elif tag.name == 'script' and tag.get('src'):
+                        resource_urls.append(urljoin(url, tag['src']))
+                    elif tag.name == 'link' and tag.get('href'):
+                        if tag.get('rel') and 'stylesheet' in tag.get('rel'):
+                            resource_urls.append(urljoin(url, tag['href']))
+                    elif tag.name == 'a' and tag.get('href'):
+                        href = tag['href']
+                        if not href.startswith('#'):
+                            resource_urls.append(urljoin(url, href))
+
+                seen = set()
+                for res_url in resource_urls:
+                    if res_url in seen:
+                        continue
+                    seen.add(res_url)
+                    try:
+                        download_file(res_url, temp_dir)
+                    except Exception:
+                        pass
+
+            zip_path = shutil.make_archive(temp_dir, 'zip', temp_dir)
+            return send_file(zip_path, as_attachment=True, download_name='webpage.zip')
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return render_template('download.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a Python script for downloading a web page and its resources

## Testing
- `python3 -m py_compile download_page_resources.py`
- `python3 download_page_resources.py <<EOF
http://example.com
n
EOF` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684450207efc8327840f017027bac19d